### PR TITLE
Iss-8_Windows_not_resized_in_mobile_version

### DIFF
--- a/media/PyPlex/css/home.css
+++ b/media/PyPlex/css/home.css
@@ -1,12 +1,23 @@
+table {
+  max-width: 98%;
+  table-layout: fixed;
+}
+
 th {
   font-size: 14px;
   font-weight: normal;
 }
+
 #LinksAktiv {
   font-weight: normal;
   font-size: 14px;
 }
+
 .lbl_status {
   font-size: 14px;
   font-weight: normal;
+}
+
+td {
+  word-wrap: break-word;
 }

--- a/media/PyPlex/css/window.css
+++ b/media/PyPlex/css/window.css
@@ -71,3 +71,8 @@
     margin-left: 15px;
     cursor: pointer;
 }
+
+#upload-file-info {
+    word-wrap: break-word;
+}
+

--- a/media/js/PyPlex/base.js
+++ b/media/js/PyPlex/base.js
@@ -235,5 +235,20 @@ function on_captcha_click(c) {
     var y = (c.pageY - $(this).offset().top).toFixed(0);
     $("#cap_box #cap_result").val( x + ' , ' + y );
     return submit_captcha();
-}; 
+};
+
+// if file-button click/change, then upload-file-info-label will get filename. 
+$(document).on('change', '#add_file', function() {
+    $('#upload-file-info').text($(this).val().replace(/C:\\fakepath\\/i, ''));
+});
+
+// if window resize, then progress-bar-td tag will change colspan.
+$(window).on('resize', function() {
+    if ($(window).width() < 767) {
+        $('.progress-bar-td').attr('colspan','3');
+    } else {
+        $('.progress-bar-td').attr('colspan','5');
+    }
+});
+
 {% endautoescape %}

--- a/media/js/PyPlex/home.js
+++ b/media/js/PyPlex/home.js
@@ -147,6 +147,10 @@ function LinkEntry(id){
             $(statusspan).html(item.statusmsg);
             $(statusspan).removeClass().addClass('label '+ labelcolor(item.status) + ' lbl_status');
             var name = document.createElement("td");
+            $(name).addClass('dl_name');
+            $(name).css('word-wrap', 'break-word');
+            $(name).css('max-width', '100%');
+            $(name).css('display', 'inline-block');
             $(name).html(item.name);
             var info = document.createElement("td");
             $(info).html(item.info);
@@ -217,7 +221,13 @@ function LinkEntry(id){
         this.elements.tr.appendChild(child);
 
         var secondchild = document.createElement('td');
-        $(secondchild).attr('colspan',5);
+        $(secondchild).addClass('progress-bar-td');
+        // change colspan when window-width is under 767px
+        if ($(window).width() < 767) {
+ 	    $(secondchild).attr('colspan', '3');
+ 	} else {
+	    $(secondchild).attr('colspan', '5');
+        }
         secondchild.appendChild(this.elements.progress);
 
         this.elements.pgbTr.appendChild(secondchild);

--- a/templates/PyPlex/window.html
+++ b/templates/PyPlex/window.html
@@ -57,7 +57,7 @@ textarea.form-control:focus {
   <div class="form-group">
   <label for="add_file">{{_("Upload a container.")}}</label> <p> 
   <label class="btn btn-warning" for="add_file" style="padding: 0 10%;">
-    <input name="add_file" id="add_file" type="file" style="display:none;" onchange="$('upload-file-info').set('text', $(this).get('value'));">
+    <input name="add_file" id="add_file" type="file" style="display:none;">
     {{_("File")}}
   </label>
   <span id="upload-file-info">{{_("not available")}}</span>


### PR DESCRIPTION
Bugfix: Table not responsible when item-name is to long, thanks Alessandro (https://github.com/xunil75/PyPlex/issues/8).

Bugfix: When selecting a file with modal window, the label show the filename.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/xunil75/PyPlex/pull/9?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xunil75/PyPlex/pull/9'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>