### PR TITLE
Links-TextArea in Modal "Add Package" was too height.

### DIFF
--- a/templates/PyPlex/window.html
+++ b/templates/PyPlex/window.html
@@ -1,7 +1,7 @@
 <style>
 
 textarea.form-control {
-    height: 100%;
+    height: 30%;
     margin: 5px 0 5px 0;
     color: #fff;
     border: 0px solid #444;


### PR DESCRIPTION
Now its 30% of height, but 20% would be also good. Can experiment it.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/xunil75/PyPlex/pull/11?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xunil75/PyPlex/pull/11'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>